### PR TITLE
SIL-34: Removed typedefs and added using keyword

### DIFF
--- a/client/src/client/include/chatroom_model.h
+++ b/client/src/client/include/chatroom_model.h
@@ -13,7 +13,7 @@ using std::string;
 
 class ClientPrototype;
 
-typedef std::shared_ptr<ClientPrototype> ClientPrototype_ptr;
+using ClientPrototype_ptr = std::shared_ptr<ClientPrototype>;
 
 
 

--- a/client/src/client/include/client.h
+++ b/client/src/client/include/client.h
@@ -35,9 +35,8 @@ using shared_ptr = std::shared_ptr<T>;
 template <typename T>
 using unique_ptr = std::unique_ptr<T>;
 
-typedef shared_ptr<Net::BasicConnectionHandler> BasicConnectionHandlerSharedPtr;
-
-typedef shared_ptr<Net::BasicCommunicationModel> BasicCommunicationModelSharedPtr;
+using BasicConnectionHandlerSharedPtr = shared_ptr<Net::BasicConnectionHandler>;
+using BasicCommunicationModelSharedPtr = shared_ptr<Net::BasicCommunicationModel>;
 
 class ClientModel {
  public:

--- a/client/src/client/include/communication_unit.h
+++ b/client/src/client/include/communication_unit.h
@@ -38,8 +38,7 @@ constexpr auto max_write_th_count = 3;
 namespace Net {
 template <typename T>
 using unique_ptr = std::unique_ptr<T>;
-
-typedef shared_ptr<iounit::IOModel> IOModel_shrd_ptr;
+using IOModel_shrd_ptr = shared_ptr<iounit::IOModel> ;
 
 class BasicCommunicationModel {
  public:

--- a/client/src/client/include/connection_handler.h
+++ b/client/src/client/include/connection_handler.h
@@ -38,8 +38,7 @@ using shared_ptr = std::shared_ptr<T>;
 
 template <typename T>
 using unique_ptr = std::unique_ptr<T>;
-
-typedef unique_ptr<struct sockaddr_in> sockaddr_in_unq_ptr;
+using sockaddr_in_unq_ptr = unique_ptr<struct sockaddr_in> ;
 
 class BasicConnectionHandler {
  public:

--- a/client/src/client/include/handler.h
+++ b/client/src/client/include/handler.h
@@ -64,13 +64,9 @@ enum class CONNECT_STATE {
 namespace Client {
 class Handler;
 /*Binding which help to add new handler functions genreically*/
-typedef std::map<std::string,
-				 int (Handler::*)(int, const DataTransfer::MessageModel&),
-				 ::strless>
-	CommMapType;
-
-  /* this command map is used to process key codes passed from client interface */
-typedef std::unordered_map<std::string, std::string> InputCommMapType;
+using CommMapType = std::map<std::string, int (Handler::*)(int, const DataTransfer::MessageModel&), ::strless>;
+/* this command map is used to process key codes passed from client interface */
+using InputCommMapType = std::unordered_map<std::string, std::string>;
 
 
 class Handler {

--- a/client/src/client/include/io_unit.h
+++ b/client/src/client/include/io_unit.h
@@ -36,7 +36,7 @@ namespace iounit {
 template <typename T>
 using shared_ptr = std::shared_ptr<T>;
 
-typedef shared_ptr<Client::Handler> Handler_shrd_ptr;
+using Handler_shrd_ptr = shared_ptr<Client::Handler>;
 
 class IOModel {
  public:

--- a/server/src/server/src/main.cpp
+++ b/server/src/server/src/main.cpp
@@ -32,8 +32,7 @@ int main(int argc, char *argv[]) {
 
   // Start listening. Hold at most 10 connections in the queue
   if (listen(sockfd, 1) < 0) {
-    Debug().fatal("Failed to listen on socket. errno: ", errno,
-                  ", terminating...");
+    Debug().fatal("Failed to listen on socket. errno: ", errno, ", terminating...");
     exit(EXIT_FAILURE);
   }
   int connection;


### PR DESCRIPTION
As noted in ticket SIL-34, some code needed to be refactored, and typedef keyword was replaced with standard supported using keyword.